### PR TITLE
Works with osTicket v1.17, plus additional option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # osticket-auto-unassign
 This plugin unassigns a team or agent whenever the other is assigned, so a ticket is always either assigned to an agent or a team (not both) (based on https://forum.osticket.com/d/90581-need-to-be-able-to-unassign-team-when-reassigning-to-an-individual/8)
+
+It has been edited on 27.10.2022 to make it compatible with osTicket v1.17 (1d8b790)
+As well to have the following two options:
+	- Unassigns a team or agent whenever the other is assigned, so a ticket is always either assigned to an agent or a team (not both)
+	- Unassigns automatically the Agent when assigning the ticket to another Team. (A ticket can then be assigned to a Team and an Agent at the same time)

--- a/UitAutoUnassign.php
+++ b/UitAutoUnassign.php
@@ -7,7 +7,7 @@ require_once (INCLUDE_DIR . 'class.app.php');
 require_once('config.php'); // Added on 27.10.2022 Angel Andrades
 
 class UitAutoUnassign extends Plugin {
-	var $config_class = 'UitAutoUnassignEditedConfig'; // Added on 27.10.2022 Angel Andrades
+	var $config_class = 'UitAutoUnassignConfig'; // Added on 27.10.2022 Angel Andrades
     public function bootstrap() {
         //catch the signal from Ticket::assignToStaff
         Signal::connect('object.edited', function($ticket, $type) {

--- a/UitAutoUnassign.php
+++ b/UitAutoUnassign.php
@@ -4,11 +4,14 @@ require_once (INCLUDE_DIR . 'class.plugin.php');
 require_once (INCLUDE_DIR . 'class.signal.php');
 require_once (INCLUDE_DIR . 'class.app.php');
 
-class UitAutoUnassign extends Plugin {
+require_once('config.php'); // Added on 27.10.2022 Angel Andrades
 
+class UitAutoUnassign extends Plugin {
+	var $config_class = 'UitAutoUnassignEditedConfig'; // Added on 27.10.2022 Angel Andrades
     public function bootstrap() {
         //catch the signal from Ticket::assignToStaff
         Signal::connect('object.edited', function($ticket, $type) {
+			$config = $this->getConfig();
             if (
                 $ticket instanceof Ticket
                 && is_array($type)
@@ -17,19 +20,55 @@ class UitAutoUnassign extends Plugin {
                 && $ticket->getStaffId() > 0
                 && $ticket->getTeamId() > 0
             ) {
-                if (array_key_exists("team", $type)) {
-                    //assigned to team, remove agent
-                    $ticket->setStaffId(0);
-                    //$ticket->logNote("Unassigned", "Plugin dummy: Assignment zum Agent aufgehoben: ".print_r($type, true));
-                }
-                else {
-                    //assignment ot agent, remove team
-                    $ticket->setTeamId(0);
-                    //$ticket->logNote("Unassigned", "Plugin dummy: Assignment zum Team aufgehoben: ".print_r($type, true));
-                }
+				// Added on 27.10.2022 Angel Andrades
+				switch($config->get('unassign_options')){ 
+					case 'one_assign':
+						if (array_key_exists("team", $type)) {
+							//assigned to team, remove agent
+							$ticket->setStaffId(0);
+							//$ticket->logNote("Unassigned", "Plugin dummy: Assignment zum Agent aufgehoben: ".print_r($type, true));
+						}
+						else {
+							//assignment ot agent, remove team
+							$ticket->setTeamId(0);
+							//$ticket->logNote("Unassigned", "Plugin dummy: Assignment zum Team aufgehoben: ".print_r($type, true));
+						}
+						break;
+					case 'unassign_agent':
+						if (array_key_exists("team", $type)) {
+							//assigned to team, remove agent
+							$ticket->setStaffId(0);
+							//$ticket->logNote("Unassigned", "Plugin dummy: Assignment zum Agent aufgehoben: ".print_r($type, true));
+						}
+						break;
+				}	
+				
             }
                     
         });
+    }
+	
+	 /**
+     * Required stub.
+     *
+     * {@inheritdoc}
+     *
+     * @see Plugin::uninstall()
+     */
+    function uninstall(&$errors) {
+        $errors = array();
+        global $ost;
+        // Send an alert to the system admin:
+        $ost->alertAdmin(self::PLUGIN_NAME . ' has been uninstalled', "You wanted that right?", true);
+
+        parent::uninstall($errors);
+    }
+
+    /**
+     * Plugins seem to want this.
+     */
+    public function getForm() {
+        return array();
     }
 
 }

--- a/config.php
+++ b/config.php
@@ -1,0 +1,51 @@
+<?php
+
+//require_once(INCLUDE_DIR.'class.forms.php');
+require_once INCLUDE_DIR . 'class.plugin.php';
+require_once INCLUDE_DIR.'class.forms.php';
+
+// Created on 27.10.2022 Angel Andrades
+
+class UitAutoUnassignEditedConfig extends PluginConfig {
+	
+	// Provide compatibility function for versions of osTicket prior to
+    // translation support (v1.9.4)
+    function translate() {
+        if (!method_exists('Plugin', 'translate')) {
+            return array(
+                function($x) { return $x; },
+                function($x, $y, $n) { return $n != 1 ? $y : $x; },
+            );
+        }
+        return Plugin::translate('auto-unassign');
+    }
+	
+    function getOptions() {
+        return array(
+		
+            /*'unassign_agent' => new BooleanField(array(
+                'label' => __('Unassign Agent'),
+                'default' => true,
+                'configuration' => array(
+                    'desc' => __('Release Assigned Agent when assigning to another Team')
+                )			
+            )),*/
+			'unassign_options' => new ChoiceField([
+                'label' => __('Unassign Options'),
+                'required' => false,
+                'hint' => __('Select what the osTicket should do when the assigned Agent ou Team is changed.'),
+                'default' => 'unassign_agent',
+                'choices' => array(
+                    'unassign_agent' => __('Release assigned Agent when assigning to another Team. Tickets will always stay assigned to a Team'),
+					'one_assign' => __('Unassign a Team or Agent whenever the other is assigned'),
+                )
+            ])
+        );
+    }
+    function pre_save(&$config, &$errors) {
+        global $msg;
+        if (!$errors)
+            $msg = __('Configuration updated successfully');
+        return true;
+    }
+}

--- a/config.php
+++ b/config.php
@@ -6,7 +6,7 @@ require_once INCLUDE_DIR.'class.forms.php';
 
 // Created on 27.10.2022 Angel Andrades
 
-class UitAutoUnassignEditedConfig extends PluginConfig {
+class UitAutoUnassignConfig extends PluginConfig {
 	
 	// Provide compatibility function for versions of osTicket prior to
     // translation support (v1.9.4)

--- a/plugin.php
+++ b/plugin.php
@@ -8,5 +8,5 @@ return [
     'author' => 'Upstart IT - edited by Angel Andrades',
     'description' => 'If a ticket gets assigned to an agent, unassign the team and vice versa',
     'url' => 'https://github.com/t-oster/osticket-auto-unassign',
-    'plugin' => 'UitAutoUnassignEdited.php:UitAutoUnassignEdited'
+    'plugin' => 'UitAutoUnassign.php:UitAutoUnassign'
 ];

--- a/plugin.php
+++ b/plugin.php
@@ -3,10 +3,10 @@
 set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__file__) . '/include');
 return [
     'upstart-it:unassign-team', # notrans
-    'version' => '1.0',
-    'name' => 'Upstart IT Auto Unassign',
-    'author' => 'Upstart IT',
+    'version' => '1.0 edited',
+    'name' => 'Upstart IT Auto Unassign Edited',
+    'author' => 'Upstart IT - edited by Angel Andrades',
     'description' => 'If a ticket gets assigned to an agent, unassign the team and vice versa',
     'url' => 'https://github.com/t-oster/osticket-auto-unassign',
-    'plugin' => 'UitAutoUnassign.php:UitAutoUnassign'
+    'plugin' => 'UitAutoUnassignEdited.php:UitAutoUnassignEdited'
 ];

--- a/plugin.php
+++ b/plugin.php
@@ -3,8 +3,8 @@
 set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__file__) . '/include');
 return [
     'upstart-it:unassign-team', # notrans
-    'version' => '1.0 edited',
-    'name' => 'Upstart IT Auto Unassign Edited',
+    'version' => '1.1',
+    'name' => 'Upstart IT Auto Unassign',
     'author' => 'Upstart IT - edited by Angel Andrades',
     'description' => 'If a ticket gets assigned to an agent, unassign the team and vice versa',
     'url' => 'https://github.com/t-oster/osticket-auto-unassign',


### PR DESCRIPTION
Allow to work with osTicket v1.17 and adding the option to choose between "Assigning only to Team or Agent" or "Release Agent when assigning to another Team". With this second option we can have both Team and Agent assigned.